### PR TITLE
Insert in R-tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET = _Rtree.so
 all: $(TARGET)
 
 $(TARGET): $(INCLUDES) $(SRCS) pybind.cpp
-	$(CXX) $^ $(CXXFLAGS) -I/usr/include/mk -I$(CIMPORTPATH) -o $@ -g
+	$(CXX) $^ $(CXXFLAGS) -I/usr/include/mk -I$(CIMPORTPATH) -o $@
 
 clean:
 	rm -f *.so *.o

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET = _Rtree.so
 all: $(TARGET)
 
 $(TARGET): $(INCLUDES) $(SRCS) pybind.cpp
-	$(CXX) $^ $(CXXFLAGS) -I/usr/include/mk -I$(CIMPORTPATH) -o $@
+	$(CXX) $^ $(CXXFLAGS) -I/usr/include/mk -I$(CIMPORTPATH) -o $@ -g
 
 clean:
 	rm -f *.so *.o

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -O3 -Wall -shared -fPIC `python3 -m pybind11 --includes`
 SRCS = src/Node.cpp src/Rtree.cpp
 INCLUDES = includes/Node.h includes/Rtree.h
 CIMPORTPATH = "includes"
-TARGET = _myRtree.so
+TARGET = _Rtree.so
 
 all: $(TARGET)
 
@@ -15,6 +15,6 @@ clean:
 	rm -f *.so *.o
 
 test:
-	python3 -m pytest test_Rtree.py -v
+	python3 -m pytest test_Rtree.py -v --capture=no
 
 .PHONY: all clean test

--- a/includes/Node.h
+++ b/includes/Node.h
@@ -55,13 +55,18 @@ public:
     Node(Rect, Node*, std::vector<Node*>, bool);
 
     void insertChild(Rect);
+    void removeChild(Rect);
 
     bool operator==(const Node&) const;
     bool operator!=(const Node&) const;
 
     const Rect& getRect() const { return m_rect; }
     const Node* getChild(int) const;
+    Node* getParent() const;
     const std::vector<Node*>& getChildren() const;
+    void setChildren(std::vector<Node*>);
+    void setParent(Node*);
+    void setRect(Rect);
 
     bool isLeaf() const;
 

--- a/includes/Node.h
+++ b/includes/Node.h
@@ -69,6 +69,8 @@ public:
     void setChildren(std::vector<Node*>);
     void setParent(Node*);
     void setRect(Rect);
+    void setIsLeaf(bool);
+    void updateRect(Node*, Rect);
 
     bool isLeaf() const;
 

--- a/includes/Node.h
+++ b/includes/Node.h
@@ -36,6 +36,7 @@ public:
 
     const Point& getLowerLeft() const { return m_ll; }
     const Point& getUpperRight() const { return m_ur; } 
+    double getArea() const { return (m_ur.getLong() - m_ll.getLong()) * (m_ur.getLat() - m_ll.getLat()); }
 
 private:
     Point m_ll;
@@ -51,7 +52,7 @@ public:
     Node();
     ~Node();
 
-    Node(Rect, Node*);
+    Node(Rect, Node*, std::vector<Node*>, bool);
 
     void insertChild(Rect);
 
@@ -60,6 +61,7 @@ public:
 
     const Rect& getRect() const { return m_rect; }
     const Node* getChild(int) const;
+    const std::vector<Node*>& getChildren() const;
 
     bool isLeaf() const;
 
@@ -68,6 +70,7 @@ private:
     std::vector<Node*> m_children;
     Node* m_parent;
     bool m_isLeafNode;
+    int maxChildrenSize = 4;
 };
 
 #endif

--- a/includes/Node.h
+++ b/includes/Node.h
@@ -3,14 +3,15 @@
 
 #include <vector>
 
-// define point with logitude, latitude, 2 points make a Rect for bounding box
+// define point with logitude, latitude, 
+// 2 points(lower-left, upper-right) will make a Rect for bounding box
 class Point {
 public:
     Point();
     ~Point();
 
     Point(double, double); // longtitude, latitude
-    Point(double, double, int);
+    Point(double, double, int); // longtitude, latitude, id
 
     bool operator==(const Point&) const;
     bool operator!=(const Point&) const;
@@ -19,17 +20,18 @@ public:
     const double& getLat() const { return m_latitude; }
 
 private:    
-    double m_longtitude, m_latitude;
-    int m_id;
+    double m_longtitude; // x-coord of point
+    double m_latitude; // y-coord of point
+    int m_id; // id of point
 };
 
-// define a bounding box with 2 points, left lower and right upper
+// define a bounding box with 2 points, lower-left and upper-right
 class Rect {
 public:
     Rect();
     ~Rect();
 
-    Rect(Point, Point, int);
+    Rect(Point, Point, int); // lower-left, upper-right, id
 
     bool operator==(const Rect&) const;
     bool operator!=(const Rect&) const;
@@ -39,9 +41,9 @@ public:
     double getArea() const { return (m_ur.getLong() - m_ll.getLong()) * (m_ur.getLat() - m_ll.getLat()); }
 
 private:
-    Point m_ll;
-    Point m_ur;
-    int m_id;
+    Point m_ll; // lower-left point
+    Point m_ur; // upper-right point
+    int m_id; // id of rect
 };
 
 // define a node with a bounding box for itself
@@ -52,7 +54,7 @@ public:
     Node();
     ~Node();
 
-    Node(Rect, Node*, std::vector<Node*>, bool);
+    Node(Rect, Node*, std::vector<Node*>, bool); // rect, parent, children, isLeaf
 
     void insertChild(Rect);
     void removeChild(Rect);
@@ -71,11 +73,11 @@ public:
     bool isLeaf() const;
 
 private:
-    Rect m_rect;
-    std::vector<Node*> m_children;
-    Node* m_parent;
-    bool m_isLeafNode;
-    int maxChildrenSize = 4;
+    Rect m_rect; // bounding box of this node
+    std::vector<Node*> m_children; // children nodes
+    Node* m_parent; // parent node
+    bool m_isLeafNode; // is leaf node or not
+    int maxChildrenSize = 4; // the maximum number of children in a node
 };
 
 #endif

--- a/includes/Rtree.h
+++ b/includes/Rtree.h
@@ -13,7 +13,7 @@ public:
 
     Rtree(Node*);
 
-    const Node* getRoot() const { return m_root; }
+    const Node* getRoot() const;
     const int getSize() const { return m_treeSize; }
     double getOverlapArea(Rect, Rect);
     void setRoot(Node* root) { this->m_root = root; }

--- a/includes/Rtree.h
+++ b/includes/Rtree.h
@@ -2,6 +2,8 @@
 #define RTREE_H
 
 #include <Node.h>
+#include <cstddef>
+#include <vector>
 
 // create a R-tree with a root node
 class Rtree {

--- a/includes/Rtree.h
+++ b/includes/Rtree.h
@@ -16,18 +16,19 @@ public:
     const Node* getRoot() const { return m_root; }
     const int getSize() const { return m_treeSize; }
     double getOverlapArea(Rect, Rect);
+    void setRoot(Node* root) { this->m_root = root; }
 
     void insert(Rect);
     void remove(Rect);
     void search(Rect);
-    Node *chooseLeaf(Node*, Rect);
+    Node *chooseLeafAsParent(Node*, Rect);
     Node *splitNewNode(Node*);
     void adjustTree(Node*, Node*);
     void clearTree();
     
 
 private:
-    Node* m_root = nullptr; // the root of tree
+    Node* m_root; // the root of tree
     int m_treeSize = 0; // the number of nodes in the tree
     size_t m_maxChildren = 4; // the maximum number of children in a node
 };

--- a/includes/Rtree.h
+++ b/includes/Rtree.h
@@ -1,7 +1,7 @@
 #ifndef RTREE_H
 #define RTREE_H
 
-#include <Node.h>
+#include "Node.h"
 #include <cstddef>
 #include <vector>
 
@@ -13,7 +13,7 @@ public:
 
     Rtree(Node*);
 
-    const Node* getRoot() const;
+    Node* getRoot() const;
     const int getSize() const { return m_treeSize; }
     double getOverlapArea(Rect, Rect);
     void setRoot(Node* root) { this->m_root = root; }
@@ -25,7 +25,10 @@ public:
     Node *splitNewNode(Node*);
     void adjustTree(Node*, Node*);
     void clearTree();
-    
+
+    // traverse for debugging
+    void traverse(Node*);  
+    int getHeight(Node*);  
 
 private:
     Node* m_root; // the root of tree

--- a/includes/Rtree.h
+++ b/includes/Rtree.h
@@ -13,14 +13,20 @@ public:
 
     const Node* getRoot() const { return m_root; }
     const int getSize() const { return m_treeSize; }
+    double getOverlapArea(Rect, Rect);
 
     void insert(Rect);
     void remove(Rect);
     void search(Rect);
+    Node *chooseLeaf(Node*, Rect);
+    Node *splitNewNode(Node*);
+    void adjustTree(Node*, Node*);
+    
 
 private:
     Node* m_root = nullptr; // the root of tree
     int m_treeSize = 0; // the number of nodes in the tree
+    size_t m_maxChildren = 4; // the maximum number of children in a node
 };
 
 #endif

--- a/includes/Rtree.h
+++ b/includes/Rtree.h
@@ -21,6 +21,7 @@ public:
     Node *chooseLeaf(Node*, Rect);
     Node *splitNewNode(Node*);
     void adjustTree(Node*, Node*);
+    void clearTree();
     
 
 private:

--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,7 @@ int main(){
     // insert 2nd rect and find it's parent
     std::cout << std::endl;
     std::cout << "insert 2nd rect and find it's parent" << std::endl;
-    rtree.insert(Rect(Point(1, 1), Point(3, 3), 2));
+    rtree.insert(Rect(Point(3, 3), Point(4, 4), 2));
     std::cout << "root=" << rtree.getRoot() << std::endl;
     std::cout << "size=" << rtree.getSize() << std::endl;
     std::cout << "root's children size=" << rtree.getRoot()->getChildren().size() << std::endl;
@@ -30,5 +30,17 @@ int main(){
     std::cout << "root's children[1]=" << rtree.getRoot()->getChildren()[1] << std::endl;
     // std::cout << "root's children[1]'s parent=" << rtree.getRoot()->getChildren()[1]->getParent() << std::endl;
 
+    // insert 3rd rect which is inside r1 and find it's parent
+    std::cout << std::endl;
+    std::cout << "insert 3rd rect which is inside r1 and find it's parent" << std::endl;
+    rtree.insert(Rect(Point(0, 0), Point(1, 1), 3));
+    std::cout << "root=" << rtree.getRoot() << std::endl;
+    std::cout << "size=" << rtree.getSize() << std::endl;
+    std::cout << "root's children size=" << rtree.getRoot()->getChildren().size() << std::endl;
+    std::cout << "root's children[0]=" << rtree.getRoot()->getChildren()[0] << std::endl;
+    std::cout << "root's children[0] is leaf=" << rtree.getRoot()->getChildren()[0]->isLeaf() << std::endl;
+    std::cout << "root's children[1]=" << rtree.getRoot()->getChildren()[1] << std::endl;
+    std::cout << "root's children[1] is leaf=" << rtree.getRoot()->getChildren()[1]->isLeaf() << std::endl;
+    std::cout << "root's children[0]'s children=" << rtree.getRoot()->getChildren()[0]->getChildren()[0] << std::endl;
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -12,27 +12,10 @@ int main(){
     Rtree rtree = Rtree();
     std::cout << "root=" << rtree.getRoot() << std::endl;
     rtree.insert(Rect(Point(0, 0), Point(2, 2), 1));
-    std::cout << "root=" << rtree.getRoot() << std::endl;
-    std::cout << "size=" << rtree.getSize() << std::endl;
-    std::cout << "root's children size=" << rtree.getRoot()->getChildren().size() << std::endl;
-    std::cout << "root's children[0]=" << rtree.getRoot()->getChildren()[0] << std::endl;
-    std::cout << "root's children[0]'s parent=" << rtree.getRoot()->getChildren()[0]->getParent() << std::endl;
-
-    // insert 2nd rect and find it's parent
-    std::cout << std::endl;
-    std::cout << "insert 2nd rect and find it's parent" << std::endl;
     rtree.insert(Rect(Point(3, 3), Point(4, 4), 2));
-    std::cout << "root=" << rtree.getRoot() << std::endl;
-    std::cout << "size=" << rtree.getSize() << std::endl;
-    std::cout << "root's children size=" << rtree.getRoot()->getChildren().size() << std::endl;
-    std::cout << "root's children[0]=" << rtree.getRoot()->getChildren()[0] << std::endl;
-    std::cout << "root's children[0] is leaf=" << rtree.getRoot()->getChildren()[0]->isLeaf() << std::endl;
-    std::cout << "root's children[1]=" << rtree.getRoot()->getChildren()[1] << std::endl;
-    // std::cout << "root's children[1]'s parent=" << rtree.getRoot()->getChildren()[1]->getParent() << std::endl;
+
 
     // insert 3rd rect which is inside r1 and find it's parent
-    std::cout << std::endl;
-    std::cout << "insert 3rd rect which is inside r1 and find it's parent" << std::endl;
     rtree.insert(Rect(Point(0, 0), Point(1, 1), 3));
     std::cout << "root=" << rtree.getRoot() << std::endl;
     std::cout << "size=" << rtree.getSize() << std::endl;
@@ -42,5 +25,17 @@ int main(){
     std::cout << "root's children[1]=" << rtree.getRoot()->getChildren()[1] << std::endl;
     std::cout << "root's children[1] is leaf=" << rtree.getRoot()->getChildren()[1]->isLeaf() << std::endl;
     std::cout << "root's children[0]'s children=" << rtree.getRoot()->getChildren()[0]->getChildren()[0] << std::endl;
+
+    // insert rect
+    rtree.insert(Rect(Point(5, 5), Point(6, 6), 4));
+    rtree.insert(Rect(Point(7, 7), Point(8, 8), 5));
+    rtree.insert(Rect(Point(9, 9), Point(10, 10), 6));
+    rtree.insert(Rect(Point(3, 1), Point(4, 2), 7));
+
+    // traverse the tree
+    std::cout << std::endl;
+    std::cout << "traverse the tree" << std::endl;
+    Node *root = rtree.getRoot();
+    rtree.traverse(root);
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -2,8 +2,8 @@
 #include <vector>
 #include <algorithm>
 
-#include <Node.h>
-#include <Rtree.h>
+#include "includes/Node.h"
+#include "includes/Rtree.h"
 
 
 int main(){

--- a/main.cpp
+++ b/main.cpp
@@ -11,8 +11,24 @@ int main(){
 
     Rtree rtree = Rtree();
     std::cout << "root=" << rtree.getRoot() << std::endl;
-    rtree.insert(Rect(Point(1, 2), Point(3, 4), 1));
+    rtree.insert(Rect(Point(0, 0), Point(2, 2), 1));
     std::cout << "root=" << rtree.getRoot() << std::endl;
     std::cout << "size=" << rtree.getSize() << std::endl;
+    std::cout << "root's children size=" << rtree.getRoot()->getChildren().size() << std::endl;
+    std::cout << "root's children[0]=" << rtree.getRoot()->getChildren()[0] << std::endl;
+    std::cout << "root's children[0]'s parent=" << rtree.getRoot()->getChildren()[0]->getParent() << std::endl;
+
+    // insert 2nd rect and find it's parent
+    std::cout << std::endl;
+    std::cout << "insert 2nd rect and find it's parent" << std::endl;
+    rtree.insert(Rect(Point(1, 1), Point(3, 3), 2));
+    std::cout << "root=" << rtree.getRoot() << std::endl;
+    std::cout << "size=" << rtree.getSize() << std::endl;
+    std::cout << "root's children size=" << rtree.getRoot()->getChildren().size() << std::endl;
+    std::cout << "root's children[0]=" << rtree.getRoot()->getChildren()[0] << std::endl;
+    std::cout << "root's children[0] is leaf=" << rtree.getRoot()->getChildren()[0]->isLeaf() << std::endl;
+    std::cout << "root's children[1]=" << rtree.getRoot()->getChildren()[1] << std::endl;
+    // std::cout << "root's children[1]'s parent=" << rtree.getRoot()->getChildren()[1]->getParent() << std::endl;
+
     return 0;
 }

--- a/pybind.cpp
+++ b/pybind.cpp
@@ -46,5 +46,11 @@ PYBIND11_MODULE(_Rtree, m) {
         .def("insert", &Rtree::insert)
         .def("remove", &Rtree::remove)
         .def("search", &Rtree::search)
-        .def("chooseLeafAsParent", &Rtree::chooseLeafAsParent);
+        .def("chooseLeafAsParent", &Rtree::chooseLeafAsParent)
+        .def("getOverlapArea", &Rtree::getOverlapArea)
+        .def("splitNewNode", &Rtree::splitNewNode)
+        .def("adjustTree", &Rtree::adjustTree)
+        .def("clearTree", &Rtree::clearTree)
+        .def("traverse", &Rtree::traverse)
+        .def("getHeight", &Rtree::getHeight);
 }

--- a/pybind.cpp
+++ b/pybind.cpp
@@ -4,9 +4,11 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <vector>
+
 namespace py = pybind11;
 
-PYBIND11_MODULE(_myRtree, m) {
+PYBIND11_MODULE(_Rtree, m) {
     m.doc() = "Rtree implementation";
     py::class_<Point>(m, "Point")
         .def(py::init<>())
@@ -27,9 +29,11 @@ PYBIND11_MODULE(_myRtree, m) {
 
     py::class_<Node>(m, "Node")
         .def(py::init<>())
-        .def(py::init<Rect, Node*>())
+        .def(py::init<Rect, Node*, std::vector<Node*>, bool>())
         .def("getRect", &Node::getRect)
         .def("getChild", &Node::getChild)
+        .def("getChildren", &Node::getChildren)
+        .def("getParent", &Node::getParent)
         .def("isLeaf", &Node::isLeaf)
         .def("__eq__", &Node::operator==)
         .def("__neq__", &Node::operator!=);
@@ -41,5 +45,6 @@ PYBIND11_MODULE(_myRtree, m) {
         .def("getSize", &Rtree::getSize)
         .def("insert", &Rtree::insert)
         .def("remove", &Rtree::remove)
-        .def("search", &Rtree::search);
+        .def("search", &Rtree::search)
+        .def("chooseLeafAsParent", &Rtree::chooseLeafAsParent);
 }

--- a/pybind.cpp
+++ b/pybind.cpp
@@ -41,7 +41,7 @@ PYBIND11_MODULE(_Rtree, m) {
     py::class_<Rtree>(m, "Rtree")
         .def(py::init<>())
         .def(py::init<Node*>())
-        .def("getRoot", &Rtree::getRoot)
+        .def("getRoot", &Rtree::getRoot, py::return_value_policy::reference)
         .def("getSize", &Rtree::getSize)
         .def("insert", &Rtree::insert)
         .def("remove", &Rtree::remove)

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -51,7 +51,11 @@ bool Rect::operator!=(const Rect& r) const {
 }
 
 // Node
-Node::Node() {}
+Node::Node() { // create a single new leaf node in the tree
+    this->m_parent = nullptr;
+    this->m_children = {};
+    this->m_isLeafNode = true;
+}
 
 Node::~Node() {
     for (auto child : m_children) {
@@ -68,7 +72,10 @@ Node::Node(Rect rect, Node* parent=nullptr, std::vector<Node*> children={}, bool
 }
 
 void Node::insertChild(Rect rect) {
+    this->m_isLeafNode = false;
+    Node *newNode = new Node(rect);
     m_children.push_back(new Node(rect));
+    newNode->setParent(this);
 }
 
 void Node::removeChild(Rect rect) {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -60,13 +60,15 @@ Node::~Node() {
     delete this;
 }
 
-Node::Node(Rect rect, Node* parent) {
+Node::Node(Rect rect, Node* parent=nullptr, std::vector<Node*> children={}, bool isLeaf=false) {
     this->m_rect = rect;
     this->m_parent = parent;
+    this->m_children = children;
+    this->m_isLeafNode = isLeaf;
 }
 
 void Node::insertChild(Rect rect) {
-    m_children.push_back(new Node(rect, this));
+    m_children.push_back(new Node(rect));
 }
 
 bool Node::operator==(const Node& n) const {
@@ -79,6 +81,10 @@ bool Node::operator!=(const Node& n) const {
 
 const Node* Node::getChild(int index) const {
     return m_children[index];
+}
+
+const std::vector<Node*>& Node::getChildren() const {
+    return m_children;
 }
 
 bool Node::isLeaf() const {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -52,6 +52,7 @@ bool Rect::operator!=(const Rect& r) const {
 
 // Node
 Node::Node() { // create a single new leaf node in the tree
+    // this->m_rect = Rect(Point(0, 0), Point(0, 0), 0);
     this->m_parent = nullptr;
     this->m_children = {};
     this->m_isLeafNode = true;
@@ -112,6 +113,17 @@ void Node::setParent(Node* parent) {
 
 void Node::setRect(Rect rect) {
     this->m_rect = rect;
+}
+
+void updateRect(Node* currNode, Rect rect) {
+    // set a new rect that combine original and new rect
+    Rect newRect = currNode->getRect();
+    double llx = std::min(currNode->getRect().getLowerLeft().getLong(), rect.getLowerLeft().getLong());
+    double lly = std::min(currNode->getRect().getLowerLeft().getLat(), rect.getLowerLeft().getLat());
+    double urx = std::max(currNode->getRect().getUpperRight().getLong(), rect.getUpperRight().getLong());
+    double ury = std::max(currNode->getRect().getUpperRight().getLat(), rect.getUpperRight().getLat());
+    newRect = Rect(Point(llx, lly), Point(urx, ury), 0);
+    currNode->setRect(newRect);
 }
 
 bool Node::isLeaf() const {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -71,6 +71,10 @@ void Node::insertChild(Rect rect) {
     m_children.push_back(new Node(rect));
 }
 
+void Node::removeChild(Rect rect) {
+    // TODO
+}
+
 bool Node::operator==(const Node& n) const {
     return (this->m_rect == n.m_rect) && (this->m_children == n.m_children) && (this->m_parent == n.m_parent);
 }
@@ -85,6 +89,22 @@ const Node* Node::getChild(int index) const {
 
 const std::vector<Node*>& Node::getChildren() const {
     return m_children;
+}
+
+void Node::setChildren(std::vector<Node*> children) {
+    this->m_children = children;
+}
+
+Node* Node::getParent() const {
+    return m_parent;
+}
+
+void Node::setParent(Node* parent) {
+    this->m_parent = parent;
+}
+
+void Node::setRect(Rect rect) {
+    this->m_rect = rect;
 }
 
 bool Node::isLeaf() const {

--- a/src/Rtree.cpp
+++ b/src/Rtree.cpp
@@ -15,19 +15,75 @@ Rtree::Rtree(Node* root) {
     this->m_root = root;
 }
 
-void Rtree::insert(Rect rect1) {
-    if (this->m_root == nullptr) {
-        this->m_root = new Node(rect1, nullptr);
-    } else {
-        this->m_root->insertChild(rect1);
+void Rtree::insert(Rect rect) {
+    if (this->m_root == nullptr) { // if the tree is empty
+        this->m_root = new Node(rect, nullptr, {}, true); // rect, parent, children, isLeaf=true
+    } else { // if the tree is not empty
+        Node *parent = chooseLeaf(this->m_root, rect);
+        parent->insertChild(rect);
+
+        // if the parent has more than m_maxChildren children, then split the parent
+        if (parent->getChildren().size() > m_maxChildren) {
+            Node *splitNode = splitNewNode(parent);
+            adjustTree(parent, splitNode);
+        }
     }
     this->m_treeSize ++;
 }
 
 void Rtree::remove(Rect rect) {
-    // TODO
+    //remove the rect from the tree
 }
 
 void Rtree::search(Rect rect) {
+    // TODO
+}
+
+Node *Rtree::chooseLeaf(Node *currNode, Rect rect) {
+    // search from root, find the leaf node that has the minimum area enlargement
+    // and return the leaf node
+    if (currNode->isLeaf()) {
+        return currNode;
+    } 
+
+    Node *selectedChild = nullptr;
+    double maxOverlappedArea = 0.0;
+
+    for (auto *child : currNode->getChildren()) {
+        // if overlap of rect and child.area > maxOverlappedArea,
+        // then selectedChild = child, 
+        // maxOverlappedArea = overlap of rect and child.area
+        double overlapArea = getOverlapArea(rect, child->getRect());
+        if (overlapArea > maxOverlappedArea) {
+            selectedChild = child;
+            maxOverlappedArea = overlapArea;
+        }
+    }
+
+    // if maxOverlappedArea == 0.0, then set currNode as selectedChild,
+    // rect will be slpit as a new leaf node
+    if (maxOverlappedArea == 0.0) {
+        selectedChild = currNode;
+    }
+    return chooseLeaf(selectedChild, rect);
+    
+}
+
+double Rtree::getOverlapArea(Rect rect1, Rect rect2) {
+    // given two rectangle, calculate the overlap area
+    double overlapX = std::max(0.0, std::min(rect1.getUpperRight().getLong(), rect2.getUpperRight().getLong()) - std::max(rect1.getLowerLeft().getLong(), rect2.getLowerLeft().getLong()));
+    double overlapY = std::max(0.0, std::min(rect1.getUpperRight().getLat(), rect2.getUpperRight().getLat()) - std::max(rect1.getLowerLeft().getLat(), rect2.getLowerLeft().getLat()));
+    double overlapArea = overlapX * overlapY;
+    return overlapArea;
+}
+
+Node *Rtree::splitNewNode(Node *currNode) {
+    // split the currNode into two nodes, and return the new node
+    // TODO
+    return nullptr;
+}
+
+void Rtree::adjustTree(Node *currNode, Node *splitNode) {
+    // adjust the tree after spliting the currNode
     // TODO
 }

--- a/src/Rtree.cpp
+++ b/src/Rtree.cpp
@@ -10,6 +10,7 @@
 // Rtree
 Rtree::Rtree() {
     this->m_root = new Node();
+    this->m_treeSize = 1;
 }
 
 Rtree::~Rtree() {

--- a/src/Rtree.cpp
+++ b/src/Rtree.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <algorithm>
 #include <cmath>   
+#include <cstddef>
 
 #include <Node.h>
 #include <Rtree.h>
@@ -42,7 +43,7 @@ void Rtree::search(Rect rect) {
 }
 
 Node *Rtree::chooseLeaf(Node *currNode, Rect rect) {
-    // search from root, find the leaf node that has the minimum area enlargement
+    // search from root, find the leaf node that has the maximum overlap area with rect
     // and return the leaf node
     if (currNode->isLeaf()) {
         return currNode;
@@ -62,10 +63,11 @@ Node *Rtree::chooseLeaf(Node *currNode, Rect rect) {
         }
     }
 
-    // if maxOverlappedArea == 0.0, then set currNode as selectedChild,
-    // rect will be slpit as a new leaf node
+    // if maxOverlappedArea == 0.0, means there is no overlap between rect and currNode,
+    // then set currNode as selectedChild,
+    // rect will be split as a new leaf node
     if (maxOverlappedArea == 0.0) {
-        selectedChild = currNode;
+        return currNode;
     }
     return chooseLeaf(selectedChild, rect);
     

--- a/src/Rtree.cpp
+++ b/src/Rtree.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <vector>
+#include <algorithm>
+#include <cmath>   
 
 #include <Node.h>
 #include <Rtree.h>
@@ -52,7 +54,7 @@ Node *Rtree::chooseLeaf(Node *currNode, Rect rect) {
     for (auto *child : currNode->getChildren()) {
         // if overlap of rect and child.area > maxOverlappedArea,
         // then selectedChild = child, 
-        // maxOverlappedArea = overlap of rect and child.area
+        // maxOverlappedArea = overlap area of rect and child.area
         double overlapArea = getOverlapArea(rect, child->getRect());
         if (overlapArea > maxOverlappedArea) {
             selectedChild = child;
@@ -79,11 +81,89 @@ double Rtree::getOverlapArea(Rect rect1, Rect rect2) {
 
 Node *Rtree::splitNewNode(Node *currNode) {
     // split the currNode into two nodes, and return the new node
-    // TODO
-    return nullptr;
+
+    // sort children by x-coord of lower-left corner
+    std::sort(currNode->getChildren().begin(), currNode->getChildren().end(), [](Node *a, Node *b) {
+        return a->getRect().getLowerLeft().getLong() < b->getRect().getLowerLeft().getLong();
+    });
+
+    // split the children into two groups
+    size_t splitIndex = currNode->getChildren().size() / 2;
+    std::vector<Node*> leftGroup(currNode->getChildren().begin(), currNode->getChildren().begin() + splitIndex);
+    std::vector<Node*> rightGroup(currNode->getChildren().begin() + splitIndex, currNode->getChildren().end());
+
+    // according to the rect in leftGroup, find minimum bounding rect
+    Rect currRect = currNode->getRect();
+    bool currIsLeaf = true;
+    for (auto *child : leftGroup) {
+        Rect childRect = child->getRect();
+        double llx = std::min(childRect.getLowerLeft().getLong(), currRect.getLowerLeft().getLong());
+        double lly = std::min(childRect.getLowerLeft().getLat(), currRect.getLowerLeft().getLat());
+        double urx = std::max(childRect.getUpperRight().getLong(), currRect.getUpperRight().getLong());
+        double ury = std::max(childRect.getUpperRight().getLat(), currRect.getUpperRight().getLat());
+        currRect = Rect(Point(llx, lly), Point(urx, ury), 0);
+
+        currIsLeaf = currIsLeaf && child->isLeaf();
+    }
+
+    // update rect of currNode and update its children into half as before
+    currNode->setRect(currRect);
+    currNode->setChildren(leftGroup);
+
+    // according to the rect in rightGroup, find minimum bounding rect
+    Rect newRect = currNode->getRect();
+    bool newIsLeaf = true;
+    for (auto *child : rightGroup) {
+        Rect childRect = child->getRect();
+        double llx = std::min(childRect.getLowerLeft().getLong(), newRect.getLowerLeft().getLong());
+        double lly = std::min(childRect.getLowerLeft().getLat(), newRect.getLowerLeft().getLat());
+        double urx = std::max(childRect.getUpperRight().getLong(), newRect.getUpperRight().getLong());
+        double ury = std::max(childRect.getUpperRight().getLat(), newRect.getUpperRight().getLat());
+        newRect = Rect(Point(llx, lly), Point(urx, ury), 0);
+
+        newIsLeaf = newIsLeaf && child->isLeaf();
+    }
+
+    // create new node with the same coordinates as currNode
+    Node *newNode = new Node(newRect, nullptr, rightGroup, newIsLeaf);
+
+    return newNode;
 }
 
 void Rtree::adjustTree(Node *currNode, Node *splitNode) {
-    // adjust the tree after spliting the currNode
-    // TODO
+    // adjust the tree after a split operation
+
+    if (currNode == m_root) {
+        // if currNode is root, then create a new root
+        // with currNode and splitNode as its children
+        Rect newRect = currNode->getRect();
+        double llx = std::min(currNode->getRect().getLowerLeft().getLong(), splitNode->getRect().getLowerLeft().getLong());
+        double lly = std::min(currNode->getRect().getLowerLeft().getLat(), splitNode->getRect().getLowerLeft().getLat());
+        double urx = std::max(currNode->getRect().getUpperRight().getLong(), splitNode->getRect().getUpperRight().getLong());
+        double ury = std::max(currNode->getRect().getUpperRight().getLat(), splitNode->getRect().getUpperRight().getLat());
+        newRect = Rect(Point(llx, lly), Point(urx, ury), 0);
+
+        Node *newRoot = new Node(newRect, nullptr, {currNode, splitNode}, false);
+        currNode->setParent(newRoot);
+        splitNode->setParent(newRoot);
+        this->m_root = newRoot;
+    } else {
+        // if currNode is not root, then update the parent of currNode
+        // and insert splitNode into the parent
+        Node *parent = currNode->getParent();
+        parent->removeChild(currNode->getRect());
+        parent->insertChild(splitNode->getRect());
+
+        // if the parent has more than m_maxChildren children, then split the parent
+        if (parent->getChildren().size() > m_maxChildren) {
+            Node *splitParent = splitNewNode(parent);
+            adjustTree(parent, splitParent);
+        }
+    }
+}
+
+void Rtree::clearTree() {
+    // clear the tree
+    delete this->m_root;
+    m_root = nullptr;
 }

--- a/src/Rtree.cpp
+++ b/src/Rtree.cpp
@@ -21,6 +21,10 @@ Rtree::Rtree(Node* root) {
     this->m_root = root;
 }
 
+const Node* Rtree::getRoot() const {
+    return this->m_root;
+}
+
 void Rtree::insert(Rect rect) {
     Node *parent = chooseLeafAsParent(this->m_root, rect);
     parent->insertChild(rect);

--- a/test_Rtree.py
+++ b/test_Rtree.py
@@ -1,6 +1,7 @@
 import rtree as rtreelib
 import pytest
 import math
+import random
 
 import _Rtree
 
@@ -24,7 +25,6 @@ def test_split():
     r1 = _Rtree.Rect(p1, p2, 1)
     Rtree.insert(r1)
     assert Rtree.getSize() == 2
-    print(Rtree.getRoot()) # this will cause segmentation fault
 
     # add another rect and check the tree size is three
     p3 = _Rtree.Point(3, 3)
@@ -38,8 +38,24 @@ def test_split():
     r3 = _Rtree.Rect(p1, p5, 3) # this should be inside r1
     Rtree.insert(r3)
     assert Rtree.getSize() == 4
+    assert Rtree.getHeight(Rtree.getRoot()) < 4
 
+    # random generate points and insert them into the tree
+    for i in range(4):
+        x1 = random.randint(0, 20)
+        y1 = random.randint(0, 20)
+        p1 = _Rtree.Point(x1, y1)
 
+        x2 = random.randint(0, 20)
+        y2 = random.randint(0, 20)
+        p2 = _Rtree.Point(x2, y2)
+
+        r = _Rtree.Rect(p1, p2, i)
+        Rtree.insert(r)
+    assert Rtree.getSize() == 8
+    assert Rtree.getHeight(Rtree.getRoot()) <= 3
+
+    
 
     
     

--- a/test_Rtree.py
+++ b/test_Rtree.py
@@ -41,6 +41,7 @@ def test_split():
     assert Rtree.getHeight(Rtree.getRoot()) < 4
 
     # random generate points and insert them into the tree
+    random.seed(10)
     for i in range(4):
         x1 = random.randint(0, 20)
         y1 = random.randint(0, 20)

--- a/test_Rtree.py
+++ b/test_Rtree.py
@@ -15,7 +15,7 @@ def test_init():
     p2 = _Rtree.Point(1, 1)
     r1 = _Rtree.Rect(p1, p2, 1)
     Rtree.insert(r1)
-    assert Rtree.getSize() == 1
+    assert Rtree.getSize() == 2
 
 def test_split():
     Rtree = _Rtree.Rtree()
@@ -23,20 +23,22 @@ def test_split():
     p2 = _Rtree.Point(2, 2)
     r1 = _Rtree.Rect(p1, p2, 1)
     Rtree.insert(r1)
-    assert Rtree.getSize() == 1
-    # print(Rtree.getRoot()) # this will cause segmentation fault
+    assert Rtree.getSize() == 2
+    print(Rtree.getRoot()) # this will cause segmentation fault
 
-    # add another rect and check the tree size is two
-    p3 = _Rtree.Point(1, 1)
-    p4 = _Rtree.Point(3, 3)
+    # add another rect and check the tree size is three
+    p3 = _Rtree.Point(3, 3)
+    p4 = _Rtree.Point(4, 4)
     r2 = _Rtree.Rect(p3, p4, 2)
     Rtree.insert(r2)
-    assert Rtree.getSize() == 2
-
-    r3 = _Rtree.Rect(p1, p3, 3) # this should be inside r1
-    Rtree.insert(r3)
     assert Rtree.getSize() == 3
-    
+
+    # add another rect and check the tree size is four
+    p5 = _Rtree.Point(1, 1)
+    r3 = _Rtree.Rect(p1, p5, 3) # this should be inside r1
+    Rtree.insert(r3)
+    assert Rtree.getSize() == 4
+
 
 
     

--- a/test_Rtree.py
+++ b/test_Rtree.py
@@ -2,7 +2,7 @@ import rtree as rtreelib
 import pytest
 import math
 
-import _myRtree
+import _Rtree
 
 def test_init():
     Rtree = rtreelib.Rtree()
@@ -10,11 +10,34 @@ def test_init():
     Rtree.insert(1, (1, 1, 1, 1))
     assert Rtree.count((0, 0, 1, 1)) == 2
 
-    myRtree = _myRtree.Rtree()
-    p1 = _myRtree.Point(0, 0)
-    p2 = _myRtree.Point(1, 1)
-    r1 = _myRtree.Rect(p1, p2, 1)
-    myRtree.insert(r1)
-    assert myRtree.getSize() == 1
+    Rtree = _Rtree.Rtree()
+    p1 = _Rtree.Point(0, 0)
+    p2 = _Rtree.Point(1, 1)
+    r1 = _Rtree.Rect(p1, p2, 1)
+    Rtree.insert(r1)
+    assert Rtree.getSize() == 1
+
+def test_split():
+    Rtree = _Rtree.Rtree()
+    p1 = _Rtree.Point(0, 0)
+    p2 = _Rtree.Point(2, 2)
+    r1 = _Rtree.Rect(p1, p2, 1)
+    Rtree.insert(r1)
+    assert Rtree.getSize() == 1
+    # print(Rtree.getRoot()) # this will cause segmentation fault
+
+    # add another rect and check the tree size is two
+    p3 = _Rtree.Point(1, 1)
+    p4 = _Rtree.Point(3, 3)
+    r2 = _Rtree.Rect(p3, p4, 2)
+    Rtree.insert(r2)
+    assert Rtree.getSize() == 2
+
+    r3 = _Rtree.Rect(p1, p3, 3) # this should be inside r1
+    Rtree.insert(r3)
+    assert Rtree.getSize() == 3
+    
+
+
     
     


### PR DESCRIPTION
This work adds insert and tree balancing adjustment functions based on #2 , and updates some comments and naming for readability.

The update includes: 
- The Insert function with:
  - `chooseLeafAsParent()`: recursively choose a leaf to be the parent of the inserted node
  - `getOverlapArea()`: calculate the overlap area of the two rectangles. This is the rule of choosing the leaf as the parent.
  - `splitNewNode()`: split and return another new node when the origin node has too many children.
  - `adjustTree()`: recursively adjust the tree (bottom-up) when the tree is not balanced.
- Functions for checking the tree status:
  - `traverse()`: traverse the tree in level order
  - `getHeight()`: return tree height
- Node function: add updateRect and other get/set functions. Temporarily set `maxChildrenSize = 4`.
  - `updateRect()`: the rectangle should be updated when insert
- Function rename and comments for better readability